### PR TITLE
Add xUnit tests for manifest loader and validator

### DIFF
--- a/src/OpenSail.Core/OpenSail.Tests/Loaders/ManifestLoaderTests.cs
+++ b/src/OpenSail.Core/OpenSail.Tests/Loaders/ManifestLoaderTests.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using OpenSAIL.Core.Loaders;
+using Xunit;
+
+namespace OpenSail.Tests.Loaders;
+
+public class ManifestLoaderTests
+{
+    [Fact]
+    public void Load_ValidManifest_ReturnsManifest()
+    {
+        var json = "{" +
+                    "\"endpoints\": [{" +
+                    "\"path\": \"/test\"," +
+                    "\"method\": \"get\"," +
+                    "\"intent\": \"Test\"," +
+                    "\"description\": \"desc\"," +
+                    "\"meaning\": \"mean\"" +
+                    "}]" +
+                    "}";
+        var file = Path.GetTempFileName();
+        File.WriteAllText(file, json);
+
+        var manifest = SailManifestLoader.Load(file);
+
+        Assert.NotNull(manifest);
+        Assert.NotNull(manifest.Endpoints);
+        Assert.Single(manifest.Endpoints);
+    }
+}

--- a/src/OpenSail.Core/OpenSail.Tests/OpenSail.Tests.csproj
+++ b/src/OpenSail.Core/OpenSail.Tests/OpenSail.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenSail\OpenSail.csproj" />
+    <ProjectReference Include="..\OpenSail.CLI\OpenSail.CLI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/OpenSail.Core/OpenSail.Tests/Services/ManifestValidatorTests.cs
+++ b/src/OpenSail.Core/OpenSail.Tests/Services/ManifestValidatorTests.cs
@@ -1,0 +1,43 @@
+using System.IO;
+using OpenSAIL.Cli.Services;
+using Xunit;
+
+namespace OpenSail.Tests.Services;
+
+public class ManifestValidatorTests
+{
+    [Fact]
+    public void Validate_MissingFile_ReturnsError()
+    {
+        var validator = new ManifestValidator();
+        var result = validator.Validate(new FileInfo(Path.Combine(Path.GetTempPath(), "nonexistent.json")));
+        Assert.False(result.IsValid);
+        Assert.Contains("File does not exist.", result.Errors);
+    }
+
+    [Fact]
+    public void Validate_InvalidJson_ReturnsError()
+    {
+        var file = Path.GetTempFileName();
+        File.WriteAllText(file, "{ invalid }");
+        var validator = new ManifestValidator();
+
+        var result = validator.Validate(new FileInfo(file));
+
+        Assert.False(result.IsValid);
+        Assert.Contains("Invalid JSON", result.Errors[0]);
+    }
+
+    [Fact]
+    public void Validate_MissingRequiredFields_ReturnsError()
+    {
+        var file = Path.GetTempFileName();
+        File.WriteAllText(file, "{}");
+        var validator = new ManifestValidator();
+
+        var result = validator.Validate(new FileInfo(file));
+
+        Assert.False(result.IsValid);
+        Assert.Contains("No endpoints defined.", result.Errors);
+    }
+}

--- a/src/OpenSail.Core/OpenSail.sln
+++ b/src/OpenSail.Core/OpenSail.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenSail", "OpenSail\OpenSa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenSail.CLI", "OpenSail.CLI\OpenSail.CLI.csproj", "{B8D4F888-C0DD-4E5B-8872-F97DFBA8EA17}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenSail.Tests", "OpenSail.Tests\OpenSail.Tests.csproj", "{4DF634BD-3EF0-43CC-826E-A6359E9266A8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,6 +19,10 @@ Global
 		{B8D4F888-C0DD-4E5B-8872-F97DFBA8EA17}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B8D4F888-C0DD-4E5B-8872-F97DFBA8EA17}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B8D4F888-C0DD-4E5B-8872-F97DFBA8EA17}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B8D4F888-C0DD-4E5B-8872-F97DFBA8EA17}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {B8D4F888-C0DD-4E5B-8872-F97DFBA8EA17}.Release|Any CPU.Build.0 = Release|Any CPU
+                {4DF634BD-3EF0-43CC-826E-A6359E9266A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {4DF634BD-3EF0-43CC-826E-A6359E9266A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {4DF634BD-3EF0-43CC-826E-A6359E9266A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {4DF634BD-3EF0-43CC-826E-A6359E9266A8}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add test project `OpenSail.Tests`
- cover `SailManifestLoader` with a valid manifest test
- test `ManifestValidator` error handling (missing file, invalid JSON, missing fields)
- include test project in `OpenSail.sln`

## Testing
- `dotnet test src/OpenSail.Core/OpenSail.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7440942c832aafc812c801bad323